### PR TITLE
Fix key name to be lowercase

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -37,8 +37,6 @@ export default {
         };
     },
     created() {
-        console.log(this.field);
-
         if (this.field.dependsOn) {
             Nova.$on("nova-belongsto-depend-" + this.field.dependsOn, async dependsOnValue => {
                 this.value = "";
@@ -106,7 +104,7 @@ export default {
         },
 
         async onChange(value) {
-            Nova.$emit("nova-belongsto-depend-" + this.field.attribute, {
+            Nova.$emit("nova-belongsto-depend-" + this.field.attribute.toLowerCase(), {
                 value,
                 field: this.field
             });


### PR DESCRIPTION
dependsOn method in package will change the key to lowercase.
https://github.com/orlyapps/nova-belongsto-depend/blob/master/src/NovaBelongsToDepend.php#L67

If custom the field name and set attribute, package will not match the event key.

<img width="798" alt="key mismatch" src="https://user-images.githubusercontent.com/5094008/45583692-62472f80-b8f9-11e8-9365-9c7e3dde8c2c.png">


```php
$fields = [
    NovaBelongsToDepend::make('Level 1', 'coursePropertyLevel1', CoursePropertyLevel1::class)
                ->options(\App\CourseProperty::root()->get())
                ->rules('required')
                ->hideFromIndex(),
    NovaBelongsToDepend::make('Level 2', 'coursePropertyLevel2', CoursePropertyLevel2::class)
                ->options(\App\CourseProperty::root()->get())
                ->dependsOn('coursePropertyLevel1')
                ->rules('required')
                ->hideFromIndex(),
];
```

