### PR TITLE
NovaBelongsToDepend can be placed after another fields

### DIFF
--- a/src/Http/Controllers/FieldController.php
+++ b/src/Http/Controllers/FieldController.php
@@ -24,6 +24,10 @@ class FieldController extends Controller
             }
             return $field;
         })->flatten();
+        
+        $fields = $fields->filter(function ($value) use ($request) {
+            return ($value instanceof NovaBelongsToDepend);
+        });
 
         $field = $fields->first(function ($value, $key) use ($request) {
             return ($value instanceof NovaBelongsToDepend && $value->attribute == $request->attribute);


### PR DESCRIPTION
Filter the result's before getting the exact one removes the limitation for using NovaBelongsToDepend field BEFORE any other declared fields. @orlyapps 