### PR TITLE
Fix issue when nova-belongsto-depend is used nested

### DIFF
--- a/src/Http/Controllers/FieldController.php
+++ b/src/Http/Controllers/FieldController.php
@@ -54,7 +54,10 @@ class FieldController extends Controller
                 return $this->returnFields($field->data);
             } elseif (isset($field->meta['fields'])) {
                 return $this->returnFields($field->meta['fields']);
+            } elseif (isset($field->fields)) {
+                return $this->returnFields($field->fields);
             }
+            
             return $field;
         })->flatten();
     }


### PR DESCRIPTION
When you use a package like https://github.com/dcasia/conditional-container nova-belongsto-depend is not working because it's nested inside the other package. This fix should solve that problem.