### PR TITLE
Fix compatibility issue with compatible with Laravel\\Nova\\Fields\\F…

### DIFF
--- a/src/NovaBelongsToDepend.php
+++ b/src/NovaBelongsToDepend.php
@@ -55,7 +55,7 @@ class NovaBelongsToDepend extends BelongsTo
         };
     }
 
-    public function placeholder(string $placeholder)
+    public function placeholder($placeholder)
     {
         $this->withMeta(['placeholder' => $placeholder]);
         return $this;


### PR DESCRIPTION
Fixes the following error: Declaration of Orlyapps\NovaBelongsToDepend\NovaBelongsToDepend::placeholder(string $placeholder) should be compatible with Laravel\Nova\Fields\Field::placeholder($text)