### PR TITLE
Created setResourceParentClass.

### DIFF
--- a/src/NovaBelongsToDepend.php
+++ b/src/NovaBelongsToDepend.php
@@ -91,7 +91,17 @@ class NovaBelongsToDepend extends BelongsTo
         return $this;
     }
 
-    public function hideLinkToResourceFromDetail()
+  /**
+   * @param $parentResourceClass
+   * @return self
+   */
+  public function setResourceParentClass($parentResourceClass)
+  {
+    $this->resourceParentClass = $parentResourceClass;
+    return $this;
+  }
+
+  public function hideLinkToResourceFromDetail()
     {
         $this->showLinkToResourceFromDetail = false;
         return $this;


### PR DESCRIPTION
Hy @orlyapps,

This method was created to force the ResourceParentClass to resolve #65 situations. When using dependsOn

      NovaBelongsToDepend::make(Municipio::singularLabel(),'municipio',Municipio::class)
                         ->placeholder('Selecione o município...')
                         ->sortable()
                         ->optionsResolve(function ($unidfederativa){
                           return $unidfederativa->municipios()->get();
                         })
                         ->searchable()
                         ->setResourceParentClass(self::class)
                         ->dependsOn('unidfederativa'),