### PR TITLE
Check if attribute relation is loaded when resolving attribute value

### DIFF
--- a/src/NovaBelongsToDepend.php
+++ b/src/NovaBelongsToDepend.php
@@ -135,8 +135,15 @@ class NovaBelongsToDepend extends BelongsTo
             $this->dependKey = $resource->{$this->dependsOn}()->getForeignKeyName();
         }
 
-        $value = $resource->{$this->attribute}()->withoutGlobalScopes()->first();
-        if ($value) {
+        if ($resource->relationLoaded($this->attribute)) {
+            $value = $resource->getRelation($this->attribute);
+        }
+
+        if (empty($value)) {
+            $value = $resource->{$this->attribute}()->withoutGlobalScopes()->getResults();
+        }
+
+        if (!empty($value)) {
             $this->valueKey = $value->getKey();
             $this->value = $this->formatDisplayValue($value);
         }


### PR DESCRIPTION
When Nova goes to resolve a field value (e.g. Facility for City), this package currently fetches the related value (Facility) from the database without checking if it was previously eager loaded.

This patch yanks the logic from `parent::resolve` to check if the attribute being resolved is a relation that was previously eager loaded.
