### PR TITLE
Check if attribute relation is loaded when resolving attribute value

### DIFF
--- a/src/NovaBelongsToDepend.php
+++ b/src/NovaBelongsToDepend.php
@@ -135,7 +135,12 @@ class NovaBelongsToDepend extends BelongsTo
         $foreign = $resource->{$this->attribute}();
         $this->foreignKeyName = $foreign->getForeignKeyName();
 
-        $value = $resource->{$this->attribute}()->withoutGlobalScopes()->first();
+        if ($resource->relationLoaded($this->attribute)) {
+            $value = $resource->getRelation($this->attribute);
+        } else {
+            $value = $resource->{$this->attribute}()->withoutGlobalScopes()->first();
+        }
+        
         if ($value) {
             $this->valueKey = $value->getKey();
             $this->value = $this->formatDisplayValue($value);


### PR DESCRIPTION
Previously, @cwilby [created a PR])(https://github.com/orlyapps/nova-belongsto-depend/pull/86) due to the same problem and it was merged. But subsequent PRs have deleted his code. This PR applies the same fix.